### PR TITLE
0.3.0 release

### DIFF
--- a/join_impl/src/action_expr_chain/builder.rs
+++ b/join_impl/src/action_expr_chain/builder.rs
@@ -65,21 +65,21 @@ impl<'a> ParseChain<ActionExprChain> for ActionExprChainBuilder<'a> {
     ///
     fn build_from_parse_stream(&self, input: ParseStream<'_>) -> syn::Result<ActionExprChain> {
         let mut chain = ActionExprChain::new(None, &[]);
-        let mut group_type = ActionGroup::new(
+        let mut action_group = ActionGroup::new(
             Combinator::Initial,
             ApplicationType::Instant,
             MoveType::None,
         );
-        let mut member_index = 0;
-        let mut wrapper_count = 0i16;
+        let mut member_idx = 0;
+        let mut wrapper_count = 0isize;
 
         loop {
             let Unit {
                 parsed: mut action_expr,
                 next,
-            } = group_type.parse_stream(self, input)?;
+            } = action_group.parse_stream(self, input)?;
 
-            if member_index == 0 {
+            if member_idx == 0 {
                 // Because first expr is `Initial`
                 let exprs = action_expr.inner_exprs().expect(
                     "join: Failed to extract initial expr. This's a bug, please report it.",
@@ -128,8 +128,8 @@ impl<'a> ParseChain<ActionExprChain> for ActionExprChainBuilder<'a> {
                     break Err(input.error("Unexpected `<<<`"));
                 }
 
-                group_type = next;
-                member_index += 1;
+                action_group = next;
+                member_idx += 1;
             } else {
                 break if chain.is_empty() {
                     Err(input.error("Chain can't be empty"))

--- a/join_impl/src/join/name_constructors.rs
+++ b/join_impl/src/join/name_constructors.rs
@@ -9,27 +9,27 @@ use quote::format_ident;
 /// Constructs name for variable with given index.
 ///
 pub fn construct_var_name(index: impl Into<usize>) -> Ident {
-    format_ident!("__v{}", index.into() as u16)
+    format_ident!("__v{}", index.into())
 }
 ///
 /// Constructs step result name using given index.
 ///
 pub fn construct_step_results_name(index: impl Into<usize>) -> Ident {
-    format_ident!("__sr{}", index.into() as u16)
+    format_ident!("__sr{}", index.into())
 }
 
 ///
 /// Constructs result name with given index.
 ///
 pub fn construct_result_name(index: impl Into<usize>) -> Ident {
-    format_ident!("__r{}", index.into() as u16)
+    format_ident!("__r{}", index.into())
 }
 
 ///
 /// Constructs thread builder name with given index.
 ///
 pub fn construct_thread_builder_name(index: impl Into<usize>) -> Ident {
-    format_ident!("__j{}", index.into() as u16)
+    format_ident!("__j{}", index.into())
 }
 
 ///
@@ -77,9 +77,9 @@ pub fn construct_expr_wrapper_name(
 ) -> Ident {
     format_ident!(
         "__ew{}{}{}",
-        index.into() as u16,
-        expr_index.into() as u16,
-        internal_index.into() as u16
+        index.into(),
+        expr_index.into(),
+        internal_index.into()
     )
 }
 

--- a/join_impl/src/parse/utils.rs
+++ b/join_impl/src/parse/utils.rs
@@ -82,14 +82,14 @@ pub fn parse_until<'a, T: Parse + Clone + Debug>(
     // Parses group determiner's tokens. (for ex. => -> |> etc.)
     //
     if let Some(group) = next {
-        if let Some(group_type) = group.group_type() {
+        if let Some(combinator) = group.combinator() {
             let forked = input.fork();
             group.erase_input(&forked)?;
 
             wrap = wrapper_determiner.check_input(&forked);
-            if wrap && group_type == Combinator::UNWRAP {
+            if wrap && combinator == Combinator::UNWRAP {
                 return Err(input.error("Action can be either wrapped or unwrapped but not both"));
-            } else if wrap && !group_type.can_be_wrapper() {
+            } else if wrap && !combinator.can_be_wrapper() {
                 return Err(input.error("This combinator can't be wrapper"));
             }
             if wrap {
@@ -102,9 +102,9 @@ pub fn parse_until<'a, T: Parse + Clone + Debug>(
     Ok(Unit {
         parsed: parse2(tokens)?,
         next: next.and_then(|group| {
-            group.group_type().map(|group_type| {
+            group.combinator().map(|combinator| {
                 ActionGroup::new(
-                    group_type,
+                    combinator,
                     if deferred {
                         ApplicationType::Deferred
                     } else {
@@ -112,7 +112,7 @@ pub fn parse_until<'a, T: Parse + Clone + Debug>(
                     },
                     if wrap {
                         MoveType::Wrap
-                    } else if group_type == Combinator::UNWRAP {
+                    } else if combinator == Combinator::UNWRAP {
                         MoveType::Unwrap
                     } else {
                         MoveType::None


### PR DESCRIPTION
- Replace `u16` by `usize` (`u16` was used for memory optimization) to reduce amount of casts and avoid potential issues with large automated code generation
- Rename `group_type` to `combinator`